### PR TITLE
Fix Unusedlocalvariable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.rajeswarreddy88</groupId>
+    <artifactId>pmd-apex-rules</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <pmd.version>6.13.0-SNAPSHOT</pmd.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <release>8</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-apex</artifactId>
+            <version>${pmd.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-test</artifactId>
+            <version>${pmd.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/resources/category/apex/Customcodestyle.xml
+++ b/src/main/resources/category/apex/Customcodestyle.xml
@@ -9,6 +9,7 @@
 Rules which enforce a specific coding style.
     </description>
 
+<!--
  <rule name="CustomNoHardcodedId"
           since="5.5.0"
           message="{0} variable {1} should begin with {2}"
@@ -69,12 +70,11 @@ trigger Accounts on Account {}
 ]]>
         </example>
     </rule>
-    
+-->
      <rule name="UnUsedLocalVariableRule"
           since="5.5.0"
-          message="Avoid unused method parameters such as ''{0}''."
-          class="net.sourceforge.pmd.lang.apex.rule.bestpractice.UnUsedLocalVariableRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#variablenamingconventions">
+          message="Avoid unused local variables such as ''{0}''."
+          class="net.sourceforge.pmd.lang.apex.rule.bestpractice.UnUsedLocalVariableRule">
         <description>
 Do not used hard coded IDs
         </description>

--- a/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/UnUsedLocalVariableRule.xml
+++ b/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/UnUsedLocalVariableRule.xml
@@ -6,12 +6,15 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
-        <description>new unused parameter</description>
+        <description>unused local variable</description>
         <expected-problems>1</expected-problems>
-                
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid unused local variables such as 'errorAddedBranchSet'.</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
-    public void bar() { // param2 is unused
+    public void bar() {
        
       set<String> errorAddedBranchSet = new set<String>();
              
@@ -33,20 +36,22 @@ public class Foo {
         ]]></code>
     </test-code>
     
-<!--       <test-code>
+     <test-code>
         <description>One unused parameter</description>
         <expected-problems>1</expected-problems>
-                
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid unused local variables such as 'localVar'.</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
-    public void bar() { // param2 is unused
+    public void bar() {
       int localVar;
-             
     }
 }
         ]]></code>
     </test-code>
-    
+
      <test-code>
         <description>all Ok</description>
         <expected-problems>0</expected-problems>
@@ -54,7 +59,7 @@ public class Foo {
 public class Foo {
     public void bar() { 
      int localVar;
-          if(){
+          if(true){
         localVar="1";
        
        
@@ -62,5 +67,5 @@ public class Foo {
     }
 }
         ]]></code>
-    </test-code> -->
+    </test-code>
 </test-data>


### PR DESCRIPTION
This adds also a `pom.xml` file, so you can build and test the rule with just `mvn clean verify`. And import the project into your favorite IDE.

I've rewritten the rule to look at ASTMethod. And inside I look first for VariableDeclarations. Then I search the usages: They appear to be VariableExpressions and ReferenceExpressions.

Please note: Only with PMD 6.13.0-SNAPSHOT, the names of the referenced variables are directly available (due to the enhancement pmd/pmd#1727). Before that, you would have needed to dig into the Jorje AST nodes (ASTReferenceExpression.getNode().getNames().get(0).getValue() ...).
